### PR TITLE
New style for Talk pages

### DIFF
--- a/actdocs/static/coc.html
+++ b/actdocs/static/coc.html
@@ -1,17 +1,12 @@
-[% WRAPPER ui %]
+[% description = "The Barcelona Perl Mongers, as part of the Perl Community, believe our community should be truly open for everyone.  As such, are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, preferred operating system, programming language, or text editor." %]
+[% WRAPPER ui title="Code of Conduct" %]
   <div class="text-center wrap_title">
   <h2>
     Code of Conduct
   </h2>
   </div>
     <p class="lead">
-      The Barcelona Perl Mongers, as part of the Perl Community,
-      believe our community should be truly open for everyone.
-      As such, are committed to providing a friendly, safe and
-      welcoming environment for all, regardless of gender,
-      sexual orientation, disability, ethnicity, religion,
-      preferred operating system, programming language, or
-      text editor.
+      [% description %]
     </p>
 
     <p class="lead">

--- a/actdocs/templates/common
+++ b/actdocs/templates/common
@@ -1,4 +1,10 @@
-[%  MACRO talk_link(talk)
+[%  MACRO dotdotdot(string, limit)
+    BLOCK;
+        %]
+        [% string.substr(0, limit) %][% IF string.length > limit %]...[% END %]
+[%- END;
+
+    MACRO talk_link(talk)
     BLOCK;
         %]<a href="[% make_uri_info( 'talk', talk.talk_id ) %]">
             [%- "<b>" IF talk.accepted %]&lrm;[% talk.title %]&lrm;[% "</b>" IF talk.accepted %]</a>

--- a/actdocs/templates/core/talk/show
+++ b/actdocs/templates/core/talk/show
@@ -1,110 +1,46 @@
-[% INCLUDE js/mytalks.js %]
-
 <div class="row">
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <div class="col-md-6 form-horizontal">
-        <div class="form-group">
-          <label class="col-xs-3 control-label">{{By}}:</label>
-          <div class="col-xs-9">
-            <p class="form-control-static">
-              [% user_info(user) %]
-              [% IF global.request.user.is_talks_admin || global.request.user.user_id == user_id %]
-                (<a href="[% make_uri('edittalk', 'talk_id', talk_id) %]">{{edit}}</a>)
-              [% END %]
-            </p>
-          </div>
-        </div>
-
-        [% IF user.pm_group %]
-          <div class="form-group">
-            <label class="col-xs-3 control-label">[% loc('from').ucfirst %]:</label>
-            <div class="col-xs-9 ">
-              <p class="form-control-static">
-                [% IF user.pm_group_url %]
-                  <a href="[% user.pm_group_url %]">[% user.pm_group %]</a>
-                [% ELSE %]
-                  [% user.pm_group %]
-                [% END %]
-              </p>
-            </div>
-          </div>
-        [% END %]
-
-        <div class="form-group">
-          <label class="col-xs-3 control-label">{{Date:}}</label>
-          <div class="col-xs-9 ">
-            <p class="form-control-static">
-              [% IF datetime && ( global.config.talks_show_schedule || global.request.user.is_talks_admin ) %]
-                <a href="[% make_uri( 'schedule?day=' _ date_format(datetime, 'date_iso') ) %]" >
-                  [% date_format(datetime, 'date_full') %]
-                </a>
-                [% date_format(datetime, 'time' ) %]
+  <div class="col-sm-7 wow fadeInLeftBig talk-widget"  data-animation-delay="200">   
+    <h2>[% title %]</h2>
+            <p class="">
+              [% IF t.confirmed %]
+              <span class="label label-success">{{confirmed}}</span>
+              [% ELSIF t.accepted %]
+              <span class="label label-info">{{Accepted}}</span>
               [% ELSE %]
-                {{Not scheduled yet.}}
+              <span class="label label-warning">{{Pending}}</span>
               [% END %]
+              [% showtags(tags, 'talks') %]
             </p>
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label class="col-xs-3 control-label">{{Duration:}}</label>
-          <div class="col-xs-9 ">
-            <p class="form-control-static">
+            <span class="duration">
               [% IF lightning %]
-                {{Lightning talk}}
+                {{lightning}}
               [% ELSE %]
                 [% duration %] {{minutes}}
               [% END %]
-            </p>
-          </div>
-        </div>
+            </span>
 
+            <span class="language">
+              [% IF global.config.talks_languages %]
+                - [% global.config.talks_languages.${lang} %]
+              [% END %]
+            </span>
+
+            <span class="date">
+              [% IF global.request.user.is_talks_admin OR global.config.talks_show_schedule %]
+                [% IF datetime %] - [% date_format(datetime, 'datetime_short');ELSE; '&nbsp;'; END %]
+              [% END %]
+            </span>
         [% IF global.config.talks_levels %]
-          <div class="form-group">
-            <label class="col-xs-3 control-label">{{Target audience:}}</label>
-            <div class="col-xs-9 ">
-              <p class="form-control-static">
-                [% level %]
-              </p>
-            </div>
+          <div class="">
+            Level: [% level %]
           </div>
         [% END %]
+    <p class="lead2 abstract">
+      [% expand(chunked_abstract) | html_line_break %]&nbsp;
+    </p>
 
-        [% IF global.config.talks_languages %]
-          <div class="form-group">
-            <label class="col-xs-3 control-label">{{Language:}}</label>
-            <div class="col-xs-9 ">
-              <p class="form-control-static">
-                [% global.config.talks_languages.$lang %]&nbsp;
-              </p>
-            </div>
-          </div>
-        [% END %]
-
-        [% IF ( global.request.user.is_talks_admin || global.request.user.user_id == user_id) AND comment %]
-          <div class="form-group">
-            <label class="col-xs-3 control-label">{{Comment:}}</label>
-            <div class="col-xs-9 ">
-              <p class="form-control-static">
-                [% comment %]
-              </p>
-            </div>
-          </div>
-        [% END %]
-
-        <div class="form-group">
-          <label class="col-xs-3 control-label">{{Abstract:}}</label>
-          <div class="col-xs-9 ">
-            <p class="form-control-static">
-              [% expand(chunked_abstract) | html_line_break %]&nbsp;
-            </p>
-          </div>
-        </div>
-
+    <p>
         [% IF url_abstract || url_talk %]
-          <div class="form-group">
-            <div class="col-xs-9 col-xs-offset-3">
               [
               [% IF url_abstract %]
                 <a href="[% url_abstract %]">{{abstract (link)}}</a>
@@ -114,70 +50,140 @@
                 <a href="[% url_talk %]">{{talk (link)}}</a>
               [% END %]
               ]
-            </div>
-          </div>
+        [% END %]
+    </p>
+
+        [% IF ( global.request.user.is_talks_admin || global.request.user.user_id == user_id) AND comment %]
+              <blockquote>
+                [% comment %]
+              </blockquote>
+        [% END %]
+  </div>
+  <div class="col-md-4 col-md-offset-1 col-sm-5 wow fadeInRightBig">
+    <div class="user-widget">
+      <div class="user-widget-header">
+        [%- IF user.photo_name %]
+          <img src="/[% global.config.general_dir_photos %]/[% user.photo_name %]" class="img-thumbnail" border="0" alt="Photo">
+        [%- ELSE %]
+          <img class="img-rounded" src="../img/default-avatar.png" border="0">
         [% END %]
 
-        <div class="form-group">
-          <label class="col-xs-3 control-label">{{Tags:}}</label>
-          <div class="col-xs-9 ">
-            <p class="form-control-static">
-              [% showtags(tags, 'talks') %]
-            </p>
-          </div>
-          <div class="col-xs-9 col-xs-offset-3">
-            [% IF global.request.user %]
-              <form  method="POST" action="[% global.request.r.uri %]">
-                  <div class="input-group">
-                      <input type="text" class="form-control" name="newtags" value="" length="12" maxlength="64" />
-                      <span class="input-group-btn">
-                        <button type="submit" class="btn btn-default" id="ok" name="ok" value="{{Add}}">
-                          <i class="fa fa-plus"></i>
-                        </button>
-                      </span>
-                  </div>
-              </form>
-            [% END %]
-          </div>
-        </div>
+        <p class="name lead">
+        [%- IF user.pseudonymous %]
+          [% user.nick_name %]
+        [%- ELSE %]
+          [% user.first_name %]
+          [% user.last_name %]
+          [% "(&lrm;${user.nick_name}&lrm;)" IF user.nick_name %]
+        [% END %]
+        </p>
+        [% IF user.bio.en %]
+          <p class="lead2">[% user.bio.en %]</p>
+        [% END %]
       </div>
 
-      <div class="col-md-6">
-        [% IF attendees.size %]
-          <table class="table">
-            <thead>
-              <tr><th>{{Attended by:}}</th></tr>
-            </thead>
-            <tbody>
-              [% FOREACH u IN attendees %]
-                <tr><td>[% user_info(u) %]</tr></td>
-              [% END %]
-            </tbody>
-          </table>
-        [% END %]
+      <div class="user-widget-body">
+        <table class="table">
+        <tbody>
+          [% IF global.request.user.is_staff %]
+            <tr>
+              <td>Login</td>
+              <td>[% user.login %]</td>
+            </tr>
+          [% END %]
 
-        [% IF global.request.user.has_registered %]
-          <div class="text-right">
-            <form method="POST" action="[% make_uri('updatemytalks') %]" />
-            <input type="checkbox"
-                   name="mt-[% talk_id %]"
-                   value="[% talk_id %]"
-                   [% IF global.request.user.is_my_talk(talk_id) %]
-                     title = "{{remove from personal schedule}}"
-                     checked = "checked"
-                   [% ELSE %]
-                     title = "{{add to personal schedule}}"
-                   [% END %]
-            />
-            <span id="my-[% talk_id %]-text">{{add to personal schedule}}</span>
-            <input type="hidden" name="talk_id" value="[% talk_id %]" />
-            <input type="submit" class="mytalks_submit btn btn-primary" value="{{Submit}}" />
-            </form>
-          </div>
-        [% END %]
+          [% IF user.town %]
+            <tr>
+              <td>Town</td>
+              <td>[% user.town %]</td>
+            </tr>
+          [% END %]
+
+          [% IF user.country %]
+            <tr>
+              <td>Country</td>
+              <td>[% user.country %]</td>
+            </tr>
+          [% END %]
+
+          [% IF user.pm_group %]
+            <tr>
+              <td>Perl Mongers Group</td>
+              <td>
+                [% IF user.pm_group_url %]<a href="[% user.pm_group_url %]">[% user.pm_group %]</a>
+                [% ELSE %][% user.pm_group %][% END %]
+              </td>
+            </tr>
+          [% END %]
+
+          [% IF user.company %]
+            <tr>
+              <td>Company</td>
+              <td>
+                [% IF user.company_url %]<a href="[% user.company_url %]">[% user.company %]</a>
+                [% ELSE %][% user.company %][% END %]
+              </td>
+            </tr>
+          [% END %]
+
+          [% IF NOT user.email_hide OR global.request.user.is_users_admin %]
+            <tr>
+              <td>Email</td>
+              <td><a href="mailto:[% user.email %]">[% user.email %]</a></td>
+            </tr>
+          [% END %]
+
+          [% IF user.pause_id %]
+            <tr>
+              <td>PAUSE id</td>
+              <td>
+                <a href="https://metacpan.org/author/[% user.pause_id %]/" >[% user.pause_id %]</a>
+              </td>
+            </tr>
+          [% END %]
+
+          [% IF user.monk_id %]
+            <tr>
+              <td>Perlmonks id</td>
+              <td>
+                <a href="http://perlmonks.org/index.pl?node_id=[% user.monk_id %]" >[% user.monk_name OR user.monk_id %]</a>
+              </td>
+            </tr>
+          [% END %]
+
+          [% IF user.im %]
+            <tr>
+              <td>IM</td>
+              <td>[% user.im %]</td>
+            </tr>
+          [% END %]
+
+          [% IF user.gpg_key_id %]
+            <tr>
+              <td>GPG key ID</td>
+              <td>
+                <a href="http://pgp.mit.edu:11371/pks/lookup?op=vindex&search=0x[% user.gpg_key_id %]">0x[% user.gpg_key_id %]</a>
+              </td>
+            </tr>
+          [% END %]
+          [% IF user.web_page %]
+            <tr>
+              <td></td>
+              <td>[ <a href="[% user.web_page %]">[% user.web_page %]</a> ]</td>
+            </tr>
+          [% END %]
+        </tbody>
+        </table>
       </div>
     </div>
-    <div class="panel-footer"><a href="[% make_uri('talks') %]">&laquo; {{List of talks}}</a></div>
+  </div>
+
+  <div class="col-xs-12">   
+    [% IF global.request.user.is_talks_admin || global.request.user.user_id == user_id %]
+      <a class="btn btn-hg btn-inverse" href="[% make_uri('edittalk', 'talk_id', talk_id) %]">
+        Edit Talk
+      </a>
+    [% END %]
   </div>
 </div>
 

--- a/actdocs/templates/menu
+++ b/actdocs/templates/menu
@@ -13,7 +13,7 @@
   	<div class="collapse navbar-collapse navbar-right navbar-ex1-collapse">
       <ul class="nav navbar-nav">
         <li class="menuItem"><a href="[% make_uri('coc.html') %]">Code of Conduct</a></li>
-        <li class="menuItem"><a href="[% make_uri() %]#talks">Talks</a></li>
+        <li class="menuItem"><a href="[% make_uri('talks') %]">Talks</a></li>
         <li class="menuItem"><a href="[% make_uri() %]#sponsors">Sponsors</a></li>
         <li class="menuItem"><a href="[% make_uri() %]#venue">Venue</a></li>
         [% IF global.request.user %]

--- a/actdocs/templates/submit_talk
+++ b/actdocs/templates/submit_talk
@@ -7,24 +7,31 @@
     <div class="col-sm-6 wow fadeInLeftBig"  data-animation-delay="200">   
       <h2 class="section-heading">Submit a talk!</h2>
       <div class="sub-title lead3">
-		We're finishing up the schedule, but there's still time to submit talks
+	  	We're finishing up the schedule, but there's still time to submit talks
 	  </div>
       <p class="lead">
-		We'll have some really good and experienced speakers but we'd really 
-		<span class="hearth">♥</span> to give the opportunity to more people to talk
-		about something they like.
+        We'll have some really good and experienced speakers but we'd really 
+        <span class="hearth">♥</span> to give the opportunity to more people to talk
+        about something they like.
       </p>
+
       <p class="lead">
-		You might think that you have nothing to talk about. Think twice. What you
-		take for granted might be unknown for others. 
+        You might think that you have nothing to talk about. Think twice. What you
+        take for granted might be unknown for others. 
       </p>
+
       <p class="lead">
-		Stay tunned, we'll start publishing the first talks shortly.
+		    Stay tunned, we'll start publishing the first talks shortly.
       </p>
 
       <p>
-		<a class="btn btn-lg btn-embossed btn-primary" href="[% make_uri('newtalk') %]" role="button">Submit a Talk</a>
-	  </p> 
+		    <a class="btn btn-lg btn-embossed btn-primary" href="[% make_uri('newtalk') %]" role="button">Submit a Talk</a>
+	    </p> 
+      <p class="lead">
+        You have until the <b>26th of October</b> to submit regular talk proposals.
+        But it's possible to send lightning talk proposals after the deadline!
+      </p>
+
     </div>   
   </div>
 </div>

--- a/actdocs/templates/talk/add
+++ b/actdocs/templates/talk/add
@@ -1,4 +1,10 @@
-[% WRAPPER ui title = loc("Submit/Edit a talk") %]
+[% IF talk_id %]
+  [% page_title = "Edit talk" %]
+[% ELSE %]
+  [% page_title = "Submit a talk" %]
+[% END %]
+
+[% WRAPPER ui title = page_title %]
 
   [% PROCESS error
      msgs = {
@@ -17,6 +23,9 @@
     }
   %]
 
+  <div class="col-sm-12 wrap_title text-center">
+    <h2>[% page_title %]</h2>
+  </div>
   <form method="POST" class="form-horizontal" role="form" action="[% global.request.r.uri %]">
     [% IF return_url %]
       <input type="hidden" name="return_url" value="[% return_url %]" />
@@ -218,7 +227,7 @@
         <div class="form-group">
           [% IF tracks.size != 0 %]
             [% IF global.request.user.is_talks_admin %]
-              <label for="track_id" class="col-sm-2 control-label">{{Track}}</label>
+              <label for="track_id" class="col-sm-3 control-label">{{Track}}</label>
               <div class="col-sm-2">
                <select name="track_id" class="form-control">
                  <option value=""[% ' selected="selected"' UNLESS track_id %] />

--- a/actdocs/templates/talk/list
+++ b/actdocs/templates/talk/list
@@ -6,73 +6,36 @@
   END;
 %]
 [% WRAPPER ui title = title %]
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <p>
+  <div class="container">
+    <div class="col-sm-12 wrap_title text-center">
+      <h2>[% title %]</h2>
+
+      <p class="lead2">
         [% IF talks_total == 0 %]
           {{No talk was submitted yet.}}
         [% ELSE %]
-          {{Submitted talks:}} [% talks_total %]<br />
-          {{Accepted talks:}} [% talks_accepted %]
+          {{Submitted talks:}} [% talks_total %] -
+          {{Accepted talks:}} [% talks_accepted %] -
+          {{Accepted lightning talks:}} [% talks_lightning %]
         [% END %]
+
+	    [% IF global.request.user.is_talks_admin %]
+	      <br>
+		  {{Total duration of accepted talks:}}
+		  [% talks_duration div 60 %] {{hours}}
+		  [% talks_duration % 60 %] {{minutes}}
+	    [% END %]
       </p>
-
-      [% IF global.request.user.is_talks_admin || global.request.user.has_talk %]
-        <p>
-          {{Accepted talks are shown in bold type.}}
-        </p>
-      [% END %]
-
-      [% IF global.request.user.is_talks_admin %]
-        <p>
-          {{Total duration of accepted talks:}}
-          [% talks_duration div 60 %] {{hours}}
-          [% talks_duration % 60 %] {{minutes}}
-        </p>
-        <p>
-          {{Accepted lightning talks:}}
-          [% talks_lightning %]
-        </p>
-      [% END %]
-    </div>
+	</div>
   </div>
-
-  [% IF !tag AND tagcloud %]
-    <h2>{{Tags}}</h2>
-    [% tagcloud %]
-    <br />
-  [% END %]
-
-  [% IF tracks.size %]
-    [% first = 0 %]
-    [% FOREACH tr = tracks %]
-      [% NEXT UNLESS tr.track_id AND tr.talks.size %]
-      [% UNLESS first %]
-        [% first = 1 %]
-        <h2>{{Tracks}}</h2>
-        <ul>
-      [% END %]
-
-      <li><a href="#[% tr.track_id %]">[% tr.title %]</a></li>
-    [% END %]
-
-    [% IF first %]</ul>[% END %]
-  [% END %]
-
-  [% IF global.request.user.is_talks_admin %]
-    <form method="POST" action="[% global.request.r.uri %]">
-  [% END %]
 
   [% IF tracks.size != 0 %]
     [% FOREACH tr = tracks %]
       [% IF tr.talks.size %]
         [% IF tr.track_id %]
-          <a name="[% tr.track_id %]" ><h2>[% tr.title %]</h2></a>
-          <p>[% tr.description %]</p>
-          [% PROCESS talk/talk_list talks = tr.talks %]
+          [% PROCESS talk/talk_list talks = tr.talks table_title = tr.title table_description = tr.description %]
         [% ELSE %]
-          <h2>{{No track}}</h2>
-          [% PROCESS talk/talk_list talks = tr.talks %]
+          [% PROCESS talk/talk_list talks = tr.talks table_title = 'Without track' table_description = 'Talks not assigned to any track'%]
         [% END %]
       [% END %]
     [% END %]
@@ -80,13 +43,9 @@
     [% PROCESS talk/talk_list talks = talks %]
   [% END %]
 
-  [% IF global.request.user.is_talks_admin %]
-    <br />
-
-    [% IF talks_total != 0 %]
-      <input type="submit" class="btn btn-primary" name="ok" value="{{Update}}" />
-    [% END %]
-
-    </form>
+  [% IF !tag AND tagcloud %]
+	<div class="container">
+	  [% tagcloud %]
+	</div>
   [% END %]
 [% END %]

--- a/actdocs/templates/talk/show
+++ b/actdocs/templates/talk/show
@@ -1,3 +1,3 @@
-[% WRAPPER ui title = title %]
+[% WRAPPER ui title = title description = dotdotdot(abstract, 350) %]
   [% PROCESS core/talk/show %]
 [% END %]

--- a/actdocs/templates/talk/talk_list
+++ b/actdocs/templates/talk/talk_list
@@ -44,7 +44,7 @@
           </div>
 
           <div class="col-md-7 abstract">
-            [% t.abstract.substr(0,350) %][% IF t.abstract.length > 350 %]...[% END %]
+            [% dotdotdot(t.abstract, 350) %]
           </div>
 
           <div class="col-md-1 actions">

--- a/actdocs/templates/talk/talk_list
+++ b/actdocs/templates/talk/talk_list
@@ -1,75 +1,81 @@
 [% RETURN UNLESS talks.size %]
-[% INCLUDE js/mytalks.js %]
 
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th>{{Speaker}}</th>
-      <th>{{Talk title}}</th>
-      <th>{{Duration}}</th>
-
-      [% IF global.config.talks_languages %]
-        <th>{{Language}}</th>
-      [% END %]
-
-      [% IF global.request.user.is_talks_admin OR global.config.talks_show_schedule %]
-        <th>{{Date}}</th>
-      [% END %]
-
-      [% IF global.request.user.is_talks_admin %]
-        <th>{{Accepted}}</th>
-      [% END %]
-    </tr>
-  </thead>
+<table class="table table-striped talks-table">
+  [% IF table_title %]
+    <thead>
+      <tr>
+        <th>
+          <h3>[% table_title %]</h3>
+          <p class="lead">[% table_description %]</p>
+        </th>
+      </tr>
+    </thead>
+  [% END %]
   <tbody>
     [% FOREACH t = talks %]
-      <tr>
-        <td>
-            [% user_info(t.user) %]
-        </td>
-        <td>
-          [% IF global.request.user.has_registered %]
-            <input type="checkbox"
-                   name="mt-[% t.talk_id %]"
-                   value="[% t.talk_id %]"
-                   [% IF global.request.user.is_my_talk(t.talk_id) %]
-                     title = "{{remove from personal schedule}}"
-                     checked = "checked"
-                   [% ELSE %]
-                     title = "{{add to personal schedule}}"
-                   [% END %]
-            />
-          [% END %]
+      <tr class="talk">
+        <td class="row">
+          <div class="col-md-4">
+            <h4 clas="title">[% talk_link(t) %]</h4>
 
-          [% talk_link(t) %]
-          [% talk_modify_link(t) %]
-          [% IF t.url_abstract || t.url_talk %]<br />[[% END %]
-          [% IF t.url_abstract %]
-          <a href="[% t.url_abstract %]">{{abstract (link)}}</a>
-          [% END %]
-          [% IF t.url_talk %]
-            [% IF t.url_abstract %]-[% END %]
-          <a href="[% t.url_talk %]">{{talk (link)}}</a>
-          [% END %]
-            [% IF t.url_abstract || t.url_talk %]][% END %]
-        </td>
-        <td nowrap="nowrap">[% IF t.lightning %]
-              {{lightning}}
-            [% ELSE %]
-             [% t.duration %] {{minutes}}
+            <div class="user">
+              [% user_info(t.user) %]
+            </div>
+
+            <span class="duration">
+              [% IF t.lightning %]
+                {{lightning}}
+              [% ELSE %]
+                [% t.duration %] {{minutes}}
+              [% END %]
+            </span>
+
+            <span class="language">
+              [% IF global.config.talks_languages %]
+                - [% global.config.talks_languages.${t.lang} %]
+              [% END %]
+            </span>
+
+            <span class="date">
+              [% IF global.request.user.is_talks_admin OR global.config.talks_show_schedule %]
+                [% IF t.datetime %] - [% date_format(t.datetime, 'datetime_short');ELSE; '&nbsp;'; END %]
+              [% END %]
+            </span>
+          </div>
+
+          <div class="col-md-7 abstract">
+            [% t.abstract.substr(0,350) %][% IF t.abstract.length > 350 %]...[% END %]
+          </div>
+
+          <div class="col-md-1 actions">
+            <div class="status">
+              [% IF t.confirmed %]
+              <span class="label label-success">{{confirmed}}</span>
+              [% ELSIF t.accepted %]
+              <span class="label label-info">{{Accepted}}</span>
+              [% ELSE %]
+              <span class="label label-warning">{{Pending}}</span>
+              [% END %]
+            </div>
+
+            [% IF t.url_abstract %]
+              <div class="url-abstract">
+                [<a href="[% t.url_abstract %]">{{abstract (link)}}</a>]
+              </div>
             [% END %]
+
+            [% IF t.url_talk %]
+              <div class="url-talk">
+                [<a href="[% t.url_talk %]">{{talk (link)}}</a>]
+              </div>
+            [% END %]
+
+            <div class="edit">
+              [% talk_modify_link(t) %]
+            </div>
+          </div>
         </td>
-        [% IF global.config.talks_languages %]
-        <td>[% global.config.talks_languages.${t.lang} %]</td>
-        [% END %]
-        [% IF global.request.user.is_talks_admin OR global.config.talks_show_schedule %]
-        <td align="center" nowrap="nowrap">[% IF t.datetime; date_format(t.datetime, 'datetime_short'); ELSE; '&nbsp;'; END %]</td>
-        [% END %]
-        [% IF global.request.user.is_talks_admin %]
-        <td align="center">
-        <input type="checkbox" name="[% t.talk_id %]"[% ' checked' IF t.accepted %] />
-        </td>
-        [% END %]
       </tr>
     [% END %]
+  </tbody>
 </table>

--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -5,10 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Language" content="[% global.request.language %]" />
+		<meta name="twitter:card" content="summary" />
     <meta property="og:site_name" content="[% global.conference.name %]"/>
     <meta property="og:title" content="[% IF title %][% title %][% ELSE %][% global.conference.name %][% END %]" />
     <meta property="og:url" content="[% global.request.base_url %][% global.request.r.uri %]" />
-    <meta property="og:description" content="A free one-day conference for Perl geeks and friends." />
+    <meta property="og:description" content="[% IF description %][% description %][% ELSE %]A free one-day conference for Perl geeks and friends.[% END %]" />
     <!-- TODO: new og-image needed
     <meta property="og:image" content="[% global.request.base_url %][% make_uri_info('img', 'og-image.jpg') %]" />
     -->

--- a/wwwdocs/css/bpw2016.css
+++ b/wwwdocs/css/bpw2016.css
@@ -80,6 +80,42 @@ a {
   margin-bottom: 1em;
 }
 
+.talk-widget .abstract {
+  text-align: justify;
+}
+
+.user-widget {
+  margin-top: 30px;
+}
+
+.user-widget-header {
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  text-align: center;
+  background-color: #1abc9c;
+  border-color: #1abc9c;
+  color: #fff;
+  padding: 20px;
+}
+
+.user-widget-header .img-rounded {
+  border-radius: 200px;
+}
+
+.user-widget-header .name {
+  font-weight: bold;
+}
+
+.user-widget-body {
+  background-color: #f8f8f8;
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.user-widget-body .table tr td {
+  border-top: 1px solid #ecf0f1;
+}
+
 a.sponsor {
   display: block;
   background-image: url("../img/sponsors-2015.png");

--- a/wwwdocs/css/bpw2016.css
+++ b/wwwdocs/css/bpw2016.css
@@ -55,6 +55,31 @@ a {
   margin-top: 30px;
 }
 
+.talks-table {
+  margin-bottom: 120px;
+}
+
+.talks-table thead tr th {
+  background-color: #34495e;
+  color: white;
+  text-align: center;
+}
+
+.talks-table .talk .abstract {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+
+.talks-table .talk .actions {
+  margin-top: 15px;
+  margin-bottom: 15px;
+  text-align: center;
+}
+
+.talks-table .talk .status {
+  margin-bottom: 1em;
+}
+
 a.sponsor {
   display: block;
   background-image: url("../img/sponsors-2015.png");
@@ -88,4 +113,27 @@ a.sponsor:hover {
 
 .sponsor.upc {
   background-position: 0px -300px;
+}
+
+#htmltagcloud {
+  margin-top: 30px;
+  line-height: 4 !important;
+}
+
+#htmltagcloud span {
+  background-color: #48c9b0;
+  border-color: #48c9b0;
+  margin: 0 10px;
+  display: inline;
+  padding: .2em .6em .3em;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+
+#htmltagcloud span a{
+  color: #fff;
 }


### PR DESCRIPTION
The new styles remove some options. In this case, it means that we can move forward with the social media campaign: user pages are not linked and the talks page is all we need for now.

I'm assuming we're not using tracks but I've added the option to use them too. The page feels more neat if we don't use it, though.

New styles:
![screen shot 2016-10-01 at 16 54 56](https://cloud.githubusercontent.com/assets/2230093/19015329/5ccc27e0-87fa-11e6-9d34-852e0ccb0fd3.png)
![screen shot 2016-10-01 at 16 54 30](https://cloud.githubusercontent.com/assets/2230093/19015330/5f0db87a-87fa-11e6-88cf-9110c0da07e9.png)
