### PR TITLE
Increase (set) search limit to show all users without pagination

### DIFF
--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -5,6 +5,7 @@ default_language = en
 default_country  = es
 name_en   = Barcelona Perl Workshop 2016
 timezone  = Europe/Madrid
+searchlimit = 100
 
 [registration]
 open = 1


### PR DESCRIPTION
This will prevent /search or /faces to paginate. We're not exposing this on the site navigation but they're so convenient for administration that I always find the pagination quite annoying.

I think 100 is a safe number, way more that the people we expect.
