### PR TITLE
Change the twitter card to use bigger pictures

### DIFF
--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Language" content="[% global.request.language %]" />
-		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:card" content="summary_large_image" />
     <meta property="og:site_name" content="[% global.conference.name %]"/>
     <meta property="og:title" content="[% IF title %][% title %][% ELSE %][% global.conference.name %][% END %]" />
     <meta property="og:url" content="[% global.request.base_url %][% global.request.r.uri %]" />


### PR DESCRIPTION
I have used here "summary_large_image" to keep with the 2015 look.
From what I've seen in the [validator](https://cards-dev.twitter.com/validator) :

summary: 
- image on the left 315x315 if the image aspect ratio is not an square is from its center part
- on the right of the image:
  - title
  - abstract
  - URL
    summary_large_image | photo:
    -Image on the top 600x313  
- title
- abstract
- URL

I didn’t test the twitter:site and twitter:creator properties 

IDEA : we can use some code similar to :

`<meta name="twitter:card" content="[% IF title %]summary[% ELSE %]summary_large_image[% END %]" />`

to change the type of card depending on the page  and also change image content  to the author picture when sending the talk URL, or the sponsor banner, ...
